### PR TITLE
feat: options page infrastructure & chrome.storage.sync

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch(domain:mymemory.translated.net)",
+      "WebFetch(domain:github.com)",
+      "Bash(npm install:*)",
+      "Bash(npm run:*)",
+      "Bash(gh auth:*)",
+      "Bash(git init:*)",
+      "Bash(git config:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh repo:*)",
+      "Bash(git push:*)",
+      "Bash(git tag:*)",
+      "Bash(gh run:*)",
+      "Bash(gh project:*)",
+      "Bash(gh label:*)",
+      "Bash(gh issue create --repo JulienMaurice/x-japanese-translator --title \"Global on/off toggle\" --label \"options,priority: high\" --body \"A single switch at the top of the options page that disables all annotations site-wide.:*)",
+      "Bash(__NEW_LINE_f31791cab99ab358__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"Section toggles — reading, romaji, translations\" --label \"options,priority: high\" --body \"Let the user show/hide each annotation layer independently.:*)",
+      "Bash(__NEW_LINE_f31791cab99ab358__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"Language slot dropdowns\" --label \"options,priority: high\" --body \"Replace the hardcoded EN + FR pair with two configurable language dropdowns.:*)",
+      "Bash(__NEW_LINE_f31791cab99ab358__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"MyMemory email field \\(quota 5K → 50K chars/day\\)\" --label \"options,priority: high\" --body \"MyMemory raises the anonymous 5 000 char/day limit to 50 000 when a registered email is appended as \\\\`&de=user@example.com\\\\`.:*)",
+      "Bash(gh issue create --repo JulienMaurice/x-japanese-translator --title \"Click-to-translate mode\" --label \"options,priority: medium\" --body \"Instead of translating every Japanese tweet automatically, show the annotation shell with a «Translate» button. Translation fires only when clicked — saves the MyMemory daily quota for users who scroll through heavy Japanese feeds.:*)",
+      "Bash(__NEW_LINE_0260576495afe5dd__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"Romaji system selector\" --label \"options,priority: medium\" --body \"kuroshiro supports three romanisation systems. Let the user choose.:*)",
+      "Bash(__NEW_LINE_0260576495afe5dd__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"Skip pure katakana tokens option\" --label \"options,priority: medium\" --body \"Katakana is already phonetic — loanwords like フィクション or ゲーム don''t need a romaji annotation for intermediate learners.:*)",
+      "Bash(__NEW_LINE_0260576495afe5dd__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"Minimum Japanese character threshold\" --label \"options,priority: low\" --body \"Currently hardcoded to 2 characters. Let the user raise it to avoid annotating tweets that only contain a stray kanji.:*)",
+      "Bash(__NEW_LINE_0260576495afe5dd__ gh issue create --repo JulienMaurice/x-japanese-translator --title \"Font size control\" --label \"options,priority: low\" --body \"The annotation panel uses fixed font sizes. Let the user scale it.:*)",
+      "Bash(git checkout:*)"
+    ]
+  }
+}

--- a/build.mjs
+++ b/build.mjs
@@ -20,9 +20,10 @@ const sharedConfig = {
 };
 
 async function copyStaticFiles() {
-  // Copy manifest
   mkdirSync('dist', { recursive: true });
   copyFileSync('manifest.json', 'dist/manifest.json');
+  copyFileSync('src/options/options.html', 'dist/options.html');
+  copyFileSync('src/options/options.css', 'dist/options.css');
 
   // Copy kuromoji dictionary files
   const dictSrc = resolve(__dirname, 'node_modules/kuromoji/dict');
@@ -71,6 +72,12 @@ if (watching) {
       entryPoints: ['src/background/index.js'],
       outfile: 'dist/background.js',
       format: 'esm',
+    }),
+    build({
+      ...sharedConfig,
+      entryPoints: ['src/options/options.js'],
+      outfile: 'dist/options.js',
+      format: 'iife',
     }),
   ]);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "X Japanese Translator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Adds furigana, romaji and EN/FR translations to Japanese tweets on X",
-  "permissions": [],
+  "permissions": ["storage"],
   "host_permissions": [
     "https://x.com/*",
     "https://api.mymemory.translated.net/*"
@@ -12,6 +12,7 @@
     "service_worker": "background.js",
     "type": "module"
   },
+  "options_page": "options.html",
   "content_scripts": [
     {
       "matches": ["https://x.com/*"],

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,0 +1,33 @@
+/**
+ * Shared settings helper.
+ * Read by the content script on every page load;
+ * written by the options page via chrome.storage.sync.
+ */
+
+export const DEFAULTS = {
+  enabled: true,
+  showReading: true,        // hiragana reading above kanji
+  showRomaji: true,         // romaji subtitle
+  showLang1: true,          // first translation row
+  showLang2: true,          // second translation row
+  lang1: 'en',
+  lang2: 'fr',
+  romajiSystem: 'hepburn',  // 'hepburn' | 'nihon' | 'kunrei'
+  clickToTranslate: false,
+  myMemoryEmail: '',
+  minJapaneseChars: 2,
+};
+
+/** Returns current settings merged with defaults. */
+export async function getSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(DEFAULTS, (result) => resolve(result));
+  });
+}
+
+/** Persists a partial settings object. */
+export async function saveSettings(partial) {
+  return new Promise((resolve) => {
+    chrome.storage.sync.set(partial, resolve);
+  });
+}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,0 +1,158 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  background: #f7f9f9;
+  color: #0f1419;
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 700;
+  color: #0f1419;
+  margin-bottom: 28px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #eff3f4;
+}
+
+section {
+  margin-bottom: 28px;
+}
+
+h2 {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  color: rgba(29, 155, 240, 0.9);
+  margin-bottom: 12px;
+}
+
+/* ── Toggle row ── */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid #eff3f4;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-row input[type="checkbox"] { display: none; }
+
+.toggle {
+  flex-shrink: 0;
+  width: 40px;
+  height: 22px;
+  background: #cfd9de;
+  border-radius: 11px;
+  position: relative;
+  transition: background 0.2s;
+}
+
+.toggle::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,.2);
+  transition: transform 0.2s;
+}
+
+.toggle-row input:checked + .toggle { background: rgb(29, 155, 240); }
+.toggle-row input:checked + .toggle::after { transform: translateX(18px); }
+
+/* ── Field row ── */
+.field-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid #eff3f4;
+}
+
+.field-row.indent { padding-left: 16px; }
+
+.label-text {
+  flex: 1;
+  color: #0f1419;
+  line-height: 1.4;
+}
+
+.hint {
+  display: block;
+  font-size: 12px;
+  color: #71767b;
+  font-weight: 400;
+  margin-top: 1px;
+}
+
+select,
+input[type="number"],
+input[type="email"] {
+  flex-shrink: 0;
+  border: 1px solid #cfd9de;
+  border-radius: 6px;
+  padding: 5px 8px;
+  font-size: 13px;
+  background: #fff;
+  color: #0f1419;
+  outline: none;
+}
+
+select:focus,
+input:focus { border-color: rgb(29, 155, 240); }
+
+select { min-width: 160px; }
+input[type="number"] { width: 64px; text-align: center; }
+input[type="email"] { min-width: 200px; }
+
+/* ── Save bar ── */
+.save-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  padding: 12px 24px;
+  background: #fff;
+  border-top: 1px solid #eff3f4;
+}
+
+.status {
+  font-size: 13px;
+  color: #71767b;
+  transition: opacity 0.3s;
+}
+
+button#save {
+  background: rgb(29, 155, 240);
+  color: #fff;
+  border: none;
+  border-radius: 9999px;
+  padding: 8px 20px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+button#save:hover { background: rgb(26, 140, 216); }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>X Japanese Translator — Settings</title>
+  <link rel="stylesheet" href="options.css" />
+</head>
+<body>
+  <div class="page">
+    <h1>X Japanese Translator</h1>
+
+    <section>
+      <h2>General</h2>
+
+      <label class="toggle-row">
+        <span class="label-text">Enable extension</span>
+        <input type="checkbox" id="enabled" />
+        <span class="toggle"></span>
+      </label>
+    </section>
+
+    <section>
+      <h2>Annotation display</h2>
+
+      <label class="toggle-row">
+        <span class="label-text">Show hiragana reading <span class="hint">(blue row — kanji only)</span></span>
+        <input type="checkbox" id="showReading" />
+        <span class="toggle"></span>
+      </label>
+
+      <label class="toggle-row">
+        <span class="label-text">Show romaji <span class="hint">(grey italic row)</span></span>
+        <input type="checkbox" id="showRomaji" />
+        <span class="toggle"></span>
+      </label>
+
+      <div class="field-row">
+        <label for="romajiSystem" class="label-text">Romaji system</label>
+        <select id="romajiSystem">
+          <option value="hepburn">Hepburn (Tōkyō)</option>
+          <option value="nihon">Nihon-shiki (Tôkyô)</option>
+          <option value="kunrei">Kunrei-shiki (Tôkyô)</option>
+        </select>
+      </div>
+
+      <div class="field-row">
+        <label for="minJapaneseChars" class="label-text">
+          Minimum Japanese characters
+          <span class="hint">(skip tweets with fewer)</span>
+        </label>
+        <input type="number" id="minJapaneseChars" min="1" max="20" step="1" />
+      </div>
+    </section>
+
+    <section>
+      <h2>Translations</h2>
+
+      <label class="toggle-row">
+        <span class="label-text">Show first translation</span>
+        <input type="checkbox" id="showLang1" />
+        <span class="toggle"></span>
+      </label>
+
+      <div class="field-row indent">
+        <label for="lang1" class="label-text">Language</label>
+        <select id="lang1"></select>
+      </div>
+
+      <label class="toggle-row">
+        <span class="label-text">Show second translation</span>
+        <input type="checkbox" id="showLang2" />
+        <span class="toggle"></span>
+      </label>
+
+      <div class="field-row indent">
+        <label for="lang2" class="label-text">Language</label>
+        <select id="lang2"></select>
+      </div>
+
+      <label class="toggle-row">
+        <span class="label-text">
+          Translate on click only
+          <span class="hint">(saves daily quota)</span>
+        </span>
+        <input type="checkbox" id="clickToTranslate" />
+        <span class="toggle"></span>
+      </label>
+
+      <div class="field-row">
+        <label for="myMemoryEmail" class="label-text">
+          MyMemory account email
+          <span class="hint">(raises limit to 50 000 chars/day)</span>
+        </label>
+        <input type="email" id="myMemoryEmail" placeholder="you@example.com" />
+      </div>
+    </section>
+
+    <div class="save-bar">
+      <span id="status" class="status"></span>
+      <button id="save">Save</button>
+    </div>
+  </div>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,71 @@
+import { DEFAULTS, getSettings, saveSettings } from '../lib/settings.js';
+
+const LANGUAGES = [
+  { code: 'en', label: 'English' },
+  { code: 'fr', label: 'French' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'de', label: 'German' },
+  { code: 'pt', label: 'Portuguese' },
+  { code: 'it', label: 'Italian' },
+  { code: 'nl', label: 'Dutch' },
+  { code: 'pl', label: 'Polish' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'sv', label: 'Swedish' },
+  { code: 'tr', label: 'Turkish' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'zh', label: 'Chinese' },
+  { code: 'ko', label: 'Korean' },
+];
+
+function populateSelect(id, selected) {
+  const sel = document.getElementById(id);
+  for (const { code, label } of LANGUAGES) {
+    const opt = document.createElement('option');
+    opt.value = code;
+    opt.textContent = label;
+    if (code === selected) opt.selected = true;
+    sel.appendChild(opt);
+  }
+}
+
+function val(id) {
+  const el = document.getElementById(id);
+  if (!el) return undefined;
+  if (el.type === 'checkbox') return el.checked;
+  if (el.type === 'number') return Number(el.value);
+  return el.value;
+}
+
+function set(id, value) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  if (el.type === 'checkbox') el.checked = Boolean(value);
+  else el.value = value;
+}
+
+async function init() {
+  const settings = await getSettings();
+
+  populateSelect('lang1', settings.lang1);
+  populateSelect('lang2', settings.lang2);
+
+  for (const key of Object.keys(DEFAULTS)) {
+    if (key === 'lang1' || key === 'lang2') continue; // already set via populateSelect
+    set(key, settings[key]);
+  }
+}
+
+document.getElementById('save').addEventListener('click', async () => {
+  const updated = {};
+  for (const key of Object.keys(DEFAULTS)) {
+    updated[key] = val(key);
+  }
+
+  await saveSettings(updated);
+
+  const status = document.getElementById('status');
+  status.textContent = 'Saved.';
+  setTimeout(() => { status.textContent = ''; }, 2000);
+});
+
+init();


### PR DESCRIPTION
Closes #1

## What's in this PR
- `src/lib/settings.js` — shared `getSettings()` / `saveSettings()` helpers with typed defaults
- `src/options/options.html/css/js` — full settings UI: toggles, language dropdowns (14 languages), romaji system, email field
- `manifest.json` — `storage` permission + `options_page`, version bump to 1.1.0
- `build.mjs` — copies + bundles the options page into `dist/`

## How to open the settings
Right-click the extension icon → **Options**