### PR TITLE
feat: wire all display settings into content script

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,8 +1,13 @@
+import { getSettings } from '../lib/settings.js';
 import { startObserver } from './observer.js';
 
-// Wait for the DOM to be interactive before starting
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', startObserver);
-} else {
-  startObserver();
+async function main() {
+  const settings = await getSettings();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => startObserver(settings));
+  } else {
+    startObserver(settings);
+  }
 }
+
+main();

--- a/src/content/observer.js
+++ b/src/content/observer.js
@@ -1,41 +1,37 @@
 import { processTweet } from './processor.js';
 
 const PROCESSED_ATTR = 'data-jptrans-done';
-// Match both article and div wrappers — X sometimes changes the element type
 const TWEET_SELECTOR = '[data-testid="tweet"]';
 
-function handleArticle(article) {
+function handleArticle(article, settings) {
   if (article.hasAttribute(PROCESSED_ATTR)) return;
   article.setAttribute(PROCESSED_ATTR, 'true');
   console.log('[JpTrans] tweet found, queuing:', article);
-  processTweet(article);
+  processTweet(article, settings);
 }
 
-function scanExisting() {
+function scanExisting(settings) {
   const found = document.querySelectorAll(TWEET_SELECTOR);
   console.log(`[JpTrans] scanExisting: ${found.length} tweet(s) found`);
-  found.forEach(handleArticle);
+  found.forEach((el) => handleArticle(el, settings));
 }
 
-export function startObserver() {
-  console.log('[JpTrans] extension started on', location.href);
+export function startObserver(settings) {
+  console.log('[JpTrans] extension started on', location.href, '| enabled:', settings.enabled);
 
-  scanExisting();
-
-  // Retry scans for status pages where React renders after document_idle
-  setTimeout(scanExisting, 800);
-  setTimeout(scanExisting, 2000);
-  setTimeout(scanExisting, 4000);
+  scanExisting(settings);
+  setTimeout(() => scanExisting(settings), 800);
+  setTimeout(() => scanExisting(settings), 2000);
+  setTimeout(() => scanExisting(settings), 4000);
 
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {
         if (node.nodeType !== Node.ELEMENT_NODE) continue;
-
         if (node.matches?.(TWEET_SELECTOR)) {
-          handleArticle(node);
+          handleArticle(node, settings);
         } else if (node.querySelectorAll) {
-          node.querySelectorAll(TWEET_SELECTOR).forEach(handleArticle);
+          node.querySelectorAll(TWEET_SELECTOR).forEach((el) => handleArticle(el, settings));
         }
       }
     }
@@ -46,12 +42,12 @@ export function startObserver() {
   const originalPushState = history.pushState.bind(history);
   history.pushState = function (...args) {
     originalPushState(...args);
-    setTimeout(scanExisting, 1500);
-    setTimeout(scanExisting, 3000);
+    setTimeout(() => scanExisting(settings), 1500);
+    setTimeout(() => scanExisting(settings), 3000);
   };
 
   window.addEventListener('popstate', () => {
-    setTimeout(scanExisting, 1500);
-    setTimeout(scanExisting, 3000);
+    setTimeout(() => scanExisting(settings), 1500);
+    setTimeout(() => scanExisting(settings), 3000);
   });
 }

--- a/src/content/processor.js
+++ b/src/content/processor.js
@@ -2,52 +2,45 @@ import { initJapanese, getTokens } from '../lib/japanese.js';
 import { translate } from '../lib/translation.js';
 import { createAnnotationHost, updateAnnotation, showAnnotationError } from './renderer.js';
 
-// Hiragana + Katakana + CJK Unified Ideographs
 const JAPANESE_RE = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g;
 
 function countJapanese(text) {
   return (text.match(JAPANESE_RE) || []).length;
 }
 
-function hasEnoughJapanese(text) {
-  // At least 2 Japanese characters — low threshold to avoid false negatives
-  return countJapanese(text) >= 2;
-}
-
-// Kick off kuroshiro init eagerly so the dictionary is ready
-// before the first tweet is processed.
+// Eagerly initialise kuroshiro so the dict is ready for the first tweet
 initJapanese().catch((err) => console.error('[JpTrans] kuroshiro init failed:', err));
 
-/**
- * Processes a tweet article: reads its text, checks for Japanese,
- * creates the annotation UI, then fills it asynchronously.
- */
-export async function processTweet(article) {
+export async function processTweet(article, settings) {
+  // #2 — global toggle
+  if (!settings.enabled) return;
+
   const textEl = article.querySelector('[data-testid="tweetText"]');
   if (!textEl) {
-    console.log('[JpTrans] no tweetText in article — skipping');
+    console.log('[JpTrans] no tweetText — skipping');
     return;
   }
 
   const text = textEl.innerText || textEl.textContent || '';
   console.log(`[JpTrans] tweet text (${text.length} chars):`, text.substring(0, 80));
 
-  if (!text || !hasEnoughJapanese(text)) {
-    console.log('[JpTrans] not enough Japanese characters — skipping');
+  // #9 — configurable minimum threshold
+  if (!text || countJapanese(text) < settings.minJapaneseChars) {
+    console.log('[JpTrans] not enough Japanese — skipping');
     return;
   }
 
-  const host = createAnnotationHost(article);
-  if (!host) return; // already annotated
+  const host = createAnnotationHost(article, settings);
+  if (!host) return;
 
   try {
-    console.log('[JpTrans] starting readings + translation...');
+    console.log('[JpTrans] processing...');
     const [tokens, translations] = await Promise.all([
-      getTokens(text),
+      getTokens(text, settings),   // #7 romajiSystem, #8 skipKatakana
       translate(text),
     ]);
     console.log(`[JpTrans] done — ${tokens.length} tokens`);
-    updateAnnotation(host, tokens, translations);
+    updateAnnotation(host, tokens, translations, settings);
   } catch (err) {
     console.error('[JpTrans] processing error:', err);
     showAnnotationError(host, `Error: ${err.message}`);

--- a/src/content/renderer.js
+++ b/src/content/renderer.js
@@ -1,6 +1,11 @@
 const STYLES = `
   :host { display: block !important; }
 
+  /* ── Font size — driven by --panel-font-size custom property (#10) ── */
+  :host { --panel-font-size: 14px; }
+  :host([data-size="small"])  { --panel-font-size: 11px; }
+  :host([data-size="large"])  { --panel-font-size: 17px; }
+
   /* ── Light mode (default) ── */
   .panel {
     margin: 8px 0 4px;
@@ -9,6 +14,7 @@ const STYLES = `
     background: rgba(29, 155, 240, 0.05);
     border-radius: 0 6px 6px 0;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: var(--panel-font-size);
     box-sizing: border-box;
   }
 
@@ -165,7 +171,7 @@ function findInsertionPoint(tweetRoot, textEl) {
   return node;
 }
 
-export function createAnnotationHost(tweetRoot) {
+export function createAnnotationHost(tweetRoot, settings = {}) {
   const textEl = tweetRoot.querySelector('[data-testid="tweetText"]');
   if (!textEl) {
     console.warn('[JpTrans] tweetText not found inside', tweetRoot);
@@ -177,6 +183,10 @@ export function createAnnotationHost(tweetRoot) {
   host.setAttribute('data-jptrans-host', 'true');
   host.style.cssText = 'display:block;width:100%;';
   if (isPageDark()) host.setAttribute('data-dark', '');
+  // #10 — font size
+  if (settings.fontSize && settings.fontSize !== 'normal') {
+    host.setAttribute('data-size', settings.fontSize);
+  }
 
   const shadow = host.attachShadow({ mode: 'open' });
 
@@ -206,7 +216,13 @@ export function createAnnotationHost(tweetRoot) {
  * @param {Array}  tokens  — from getTokens()
  * @param {{ en, fr, truncated }} translations
  */
-export function updateAnnotation(host, tokens, { en, fr, truncated }) {
+export function updateAnnotation(host, tokens, { en, fr, truncated }, settings = {}) {
+  const {
+    showReading = true,   // #3
+    showRomaji  = true,   // #3
+    showLang1   = true,   // #3
+    showLang2   = true,   // #3
+  } = settings;
   if (!host?.shadowRoot) return;
 
   const panel = host.shadowRoot.querySelector('.panel');
@@ -241,17 +257,19 @@ export function updateAnnotation(host, tokens, { en, fr, truncated }) {
     surface.textContent = token.surface;
     cell.appendChild(surface);
 
-    if (token.reading) {
+    if (token.reading && showReading) {
       const reading = document.createElement('div');
       reading.className = 'token-reading';
       reading.textContent = token.reading;
       cell.appendChild(reading);
     }
 
-    const romaji = document.createElement('div');
-    romaji.className = 'token-romaji';
-    romaji.textContent = token.romaji;
-    cell.appendChild(romaji);
+    if (token.romaji && showRomaji) {
+      const romaji = document.createElement('div');
+      romaji.className = 'token-romaji';
+      romaji.textContent = token.romaji;
+      cell.appendChild(romaji);
+    }
 
     grid.appendChild(cell);
   }
@@ -263,8 +281,13 @@ export function updateAnnotation(host, tokens, { en, fr, truncated }) {
   sep.className = 'sep';
   panel.appendChild(sep);
 
-  // Translations
-  for (const { label, value } of [{ label: 'English', value: en }, { label: 'French', value: fr }]) {
+  // Translations — only render rows that are enabled (#3)
+  const translationRows = [
+    { label: 'English', value: en, show: showLang1 },
+    { label: 'French',  value: fr, show: showLang2 },
+  ].filter((r) => r.show);
+
+  for (const { label, value } of translationRows) {
     const row = document.createElement('div');
     row.className = 'row';
 

--- a/src/lib/japanese.js
+++ b/src/lib/japanese.js
@@ -14,7 +14,6 @@ export function initJapanese() {
       : 'dict/';
 
     console.log('[JpTrans] loading kuromoji dictionaries from:', dictPath);
-
     kuroshiro = new Kuroshiro();
     const analyzer = new KuromojiAnalyzer({ dictPath });
     await kuroshiro.init(analyzer);
@@ -30,39 +29,46 @@ export function initJapanese() {
   return initPromise;
 }
 
-/**
- * Converts a single kuromoji token to a display descriptor.
- *
- * Returns one of:
- *   { type: 'word',  surface, reading (hiragana|null), romaji }
- *   { type: 'plain', surface }   — punctuation / Latin / numbers
- */
-function describeToken(token) {
-  const surface = token.surface_form;
-  const katakana = token.reading; // katakana, or undefined for non-Japanese
+// wanakana romanization system identifiers
+const ROMAJI_SYSTEM_MAP = {
+  hepburn: 'hepburn',
+  nihon:   'nihonsiki',
+  kunrei:  'kunreisiki',
+};
+
+const PURE_KATAKANA_RE = /^[\u30A0-\u30FF\u30FC]+$/;
+const KANJI_RE         = /[\u4E00-\u9FFF]/;
+
+function describeToken(token, romajiSystem, skipKatakana) {
+  const surface  = token.surface_form;
+  const katakana = token.reading; // undefined for punctuation/Latin
 
   if (!katakana) return { type: 'plain', surface };
 
-  const hasKanji = /[\u4E00-\u9FFF]/.test(surface);
+  const hasKanji      = KANJI_RE.test(surface);
+  const isPureKatakana = PURE_KATAKANA_RE.test(surface);
+
+  // #8 — skip romaji for pure katakana loanwords when option is on
+  const showRomaji = !(skipKatakana && isPureKatakana);
+
   return {
     type: 'word',
     surface,
-    // Show hiragana reading only when surface contains kanji
-    // (pure hiragana/katakana tokens are already phonetic)
     reading: hasKanji ? toHiragana(katakana) : null,
-    romaji: toRomaji(katakana),
+    romaji:  showRomaji
+      ? toRomaji(katakana, { romanization: ROMAJI_SYSTEM_MAP[romajiSystem] || 'hepburn' })
+      : null,
   };
 }
 
+const JP_RUN = /[\u3000-\u9FFF\uF900-\uFAFF\uFF00-\uFFEF]+/g;
+
 /**
- * Parses text into display tokens for the word-by-word annotation view.
- *
- * Returns an array of:
- *   { type: 'word',  surface, reading, romaji }
- *   { type: 'plain', surface }
- *   { type: 'break' }    — from newlines in the original tweet
+ * Parse text into display tokens.
+ * Respects settings.romajiSystem (#7) and settings.skipKatakana (#8).
  */
-export async function getTokens(text) {
+export async function getTokens(text, settings = {}) {
+  const { romajiSystem = 'hepburn', skipKatakana = false } = settings;
   const k = await initJapanese();
   const lines = text.split('\n');
   const result = [];
@@ -70,7 +76,7 @@ export async function getTokens(text) {
   for (let i = 0; i < lines.length; i++) {
     if (i > 0) result.push({ type: 'break' });
     const tokens = await k._analyzer.parse(lines[i]);
-    result.push(...tokens.map(describeToken));
+    result.push(...tokens.map((t) => describeToken(t, romajiSystem, skipKatakana)));
   }
 
   return result;

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -13,6 +13,8 @@ export const DEFAULTS = {
   lang1: 'en',
   lang2: 'fr',
   romajiSystem: 'hepburn',  // 'hepburn' | 'nihon' | 'kunrei'
+  skipKatakana: false,      // hide romaji for pure katakana tokens
+  fontSize: 'normal',       // 'small' | 'normal' | 'large'
   clickToTranslate: false,
   myMemoryEmail: '',
   minJapaneseChars: 2,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -44,6 +44,21 @@
         </select>
       </div>
 
+      <label class="toggle-row">
+        <span class="label-text">Hide romaji for katakana words <span class="hint">(loanwords like ゲーム are already phonetic)</span></span>
+        <input type="checkbox" id="skipKatakana" />
+        <span class="toggle"></span>
+      </label>
+
+      <div class="field-row">
+        <label for="fontSize" class="label-text">Font size</label>
+        <select id="fontSize">
+          <option value="small">Small</option>
+          <option value="normal">Normal</option>
+          <option value="large">Large</option>
+        </select>
+      </div>
+
       <div class="field-row">
         <label for="minJapaneseChars" class="label-text">
           Minimum Japanese characters


### PR DESCRIPTION
Closes #2, #3, #7, #8, #9, #10

## Changes
| Issue | What changed |
|---|---|
| #2 Global toggle | `processTweet()` returns early when `enabled=false` |
| #3 Section toggles | `showReading/showRomaji/showLang1/showLang2` gate each annotation layer in renderer |
| #7 Romaji system | `getTokens()` maps hepburn/nihon/kunrei to wanakana's romanization option |
| #8 Skip katakana | `describeToken()` sets `romaji:null` for pure katakana tokens when option is on |
| #9 Min threshold | `processTweet()` uses `settings.minJapaneseChars` instead of hardcoded 2 |
| #10 Font size | `data-size` attr on shadow host; `--panel-font-size` CSS variable (11/14/17px) |

Settings loaded once at startup in `index.js` and passed down the call chain.