### PR TITLE
feat: translation settings — language slots, email quota, click-to-translate

### DIFF
--- a/src/content/processor.js
+++ b/src/content/processor.js
@@ -1,6 +1,6 @@
 import { initJapanese, getTokens } from '../lib/japanese.js';
 import { translate } from '../lib/translation.js';
-import { createAnnotationHost, updateAnnotation, showAnnotationError } from './renderer.js';
+import { createAnnotationHost, updateAnnotation, showTranslateButton, showAnnotationError } from './renderer.js';
 
 const JAPANESE_RE = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g;
 
@@ -8,23 +8,17 @@ function countJapanese(text) {
   return (text.match(JAPANESE_RE) || []).length;
 }
 
-// Eagerly initialise kuroshiro so the dict is ready for the first tweet
 initJapanese().catch((err) => console.error('[JpTrans] kuroshiro init failed:', err));
 
 export async function processTweet(article, settings) {
-  // #2 — global toggle
   if (!settings.enabled) return;
 
   const textEl = article.querySelector('[data-testid="tweetText"]');
-  if (!textEl) {
-    console.log('[JpTrans] no tweetText — skipping');
-    return;
-  }
+  if (!textEl) return;
 
   const text = textEl.innerText || textEl.textContent || '';
   console.log(`[JpTrans] tweet text (${text.length} chars):`, text.substring(0, 80));
 
-  // #9 — configurable minimum threshold
   if (!text || countJapanese(text) < settings.minJapaneseChars) {
     console.log('[JpTrans] not enough Japanese — skipping');
     return;
@@ -34,15 +28,24 @@ export async function processTweet(article, settings) {
   if (!host) return;
 
   try {
-    console.log('[JpTrans] processing...');
-    const [tokens, translations] = await Promise.all([
-      getTokens(text, settings),   // #7 romajiSystem, #8 skipKatakana
-      translate(text),
-    ]);
-    console.log(`[JpTrans] done — ${tokens.length} tokens`);
-    updateAnnotation(host, tokens, translations, settings);
+    // Tokens (reading + romaji) are always loaded immediately
+    const tokens = await getTokens(text, settings);
+
+    // #6 — click-to-translate: show tokens + a button, skip auto-translate
+    if (settings.clickToTranslate) {
+      showTranslateButton(host, tokens, settings, () => runTranslation(host, text, tokens, settings));
+      return;
+    }
+
+    await runTranslation(host, text, tokens, settings);
   } catch (err) {
     console.error('[JpTrans] processing error:', err);
     showAnnotationError(host, `Error: ${err.message}`);
   }
+}
+
+async function runTranslation(host, text, tokens, settings) {
+  const translations = await translate(text, settings);
+  console.log(`[JpTrans] translated → lang1: ${translations.lang1?.substring(0, 40)}`);
+  updateAnnotation(host, tokens, translations, settings);
 }

--- a/src/content/renderer.js
+++ b/src/content/renderer.js
@@ -127,6 +127,21 @@ const STYLES = `
     word-break: break-word;
   }
 
+  /* ── Click-to-translate button (#6) ── */
+  .translate-btn {
+    margin-top: 4px;
+    padding: 4px 14px;
+    border: 1px solid rgba(29, 155, 240, 0.5);
+    border-radius: 9999px;
+    background: transparent;
+    color: rgb(29, 155, 240);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .translate-btn:hover { background: rgba(29, 155, 240, 0.1); }
+
   /* ── States ── */
 
   .loading {
@@ -216,12 +231,20 @@ export function createAnnotationHost(tweetRoot, settings = {}) {
  * @param {Array}  tokens  — from getTokens()
  * @param {{ en, fr, truncated }} translations
  */
-export function updateAnnotation(host, tokens, { en, fr, truncated }, settings = {}) {
+// Human-readable language names for the translation row labels
+const LANG_NAMES = {
+  en: 'English', fr: 'French',  es: 'Spanish',  de: 'German',
+  pt: 'Portuguese', it: 'Italian', nl: 'Dutch', pl: 'Polish',
+  ru: 'Russian', sv: 'Swedish', tr: 'Turkish', ar: 'Arabic',
+  zh: 'Chinese', ko: 'Korean',
+};
+
+export function updateAnnotation(host, tokens, { lang1, lang2, truncated }, settings = {}) {
   const {
-    showReading = true,   // #3
-    showRomaji  = true,   // #3
-    showLang1   = true,   // #3
-    showLang2   = true,   // #3
+    showReading = true,
+    showRomaji  = true,
+    showLang1   = true,
+    showLang2   = true,
   } = settings;
   if (!host?.shadowRoot) return;
 
@@ -281,11 +304,11 @@ export function updateAnnotation(host, tokens, { en, fr, truncated }, settings =
   sep.className = 'sep';
   panel.appendChild(sep);
 
-  // Translations — only render rows that are enabled (#3)
+  // Translations — only render rows that are enabled (#3/#4)
   const translationRows = [
-    { label: 'English', value: en, show: showLang1 },
-    { label: 'French',  value: fr, show: showLang2 },
-  ].filter((r) => r.show);
+    { label: LANG_NAMES[settings.lang1] || settings.lang1 || 'English', value: lang1, show: showLang1 },
+    { label: LANG_NAMES[settings.lang2] || settings.lang2 || 'French',  value: lang2, show: showLang2 },
+  ].filter((r) => r.show && r.value);
 
   for (const { label, value } of translationRows) {
     const row = document.createElement('div');
@@ -310,6 +333,70 @@ export function updateAnnotation(host, tokens, { en, fr, truncated }, settings =
     note.textContent = 'Text was too long — translation may be partial.';
     panel.appendChild(note);
   }
+}
+
+/**
+ * #6 — Click-to-translate: render tokens immediately, show a button
+ * instead of auto-translating. Calls onTranslate() when clicked.
+ */
+export function showTranslateButton(host, tokens, settings, onTranslate) {
+  if (!host?.shadowRoot) return;
+  const panel = host.shadowRoot.querySelector('.panel');
+  panel.textContent = '';
+
+  const { showReading = true, showRomaji = true } = settings;
+  const grid = document.createElement('div');
+  grid.className = 'token-grid';
+
+  for (const token of tokens) {
+    if (token.type === 'break') {
+      const br = document.createElement('div');
+      br.className = 'token-break';
+      grid.appendChild(br);
+      continue;
+    }
+    if (token.type === 'plain') {
+      const span = document.createElement('span');
+      span.className = 'token-plain';
+      span.textContent = token.surface;
+      grid.appendChild(span);
+      continue;
+    }
+    const cell = document.createElement('div');
+    cell.className = 'token-cell';
+    const surface = document.createElement('div');
+    surface.className = 'token-surface';
+    surface.textContent = token.surface;
+    cell.appendChild(surface);
+    if (token.reading && showReading) {
+      const reading = document.createElement('div');
+      reading.className = 'token-reading';
+      reading.textContent = token.reading;
+      cell.appendChild(reading);
+    }
+    if (token.romaji && showRomaji) {
+      const romaji = document.createElement('div');
+      romaji.className = 'token-romaji';
+      romaji.textContent = token.romaji;
+      cell.appendChild(romaji);
+    }
+    grid.appendChild(cell);
+  }
+
+  panel.appendChild(grid);
+
+  const btn = document.createElement('button');
+  btn.className = 'translate-btn';
+  btn.textContent = 'Translate';
+  btn.addEventListener('click', () => {
+    btn.remove();
+    const loading = document.createElement('div');
+    loading.className = 'loading';
+    loading.textContent = 'Translating…';
+    panel.appendChild(loading);
+    onTranslate();
+  }, { once: true });
+  panel.appendChild(btn);
 }
 
 export function showAnnotationError(host, message = 'Translation failed.') {

--- a/src/lib/translation.js
+++ b/src/lib/translation.js
@@ -1,13 +1,9 @@
 const ENDPOINT = 'https://api.mymemory.translated.net/get';
-
-// MyMemory limit: ~500 chars per request.
-// We keep a safe margin and split at sentence boundaries.
 const MAX_CHARS = 450;
 
-// In-memory cache: tweet text → translation result
+// Cache keyed by "text|lang1|lang2" so language changes bust stale entries
 const cache = new Map();
 
-// Simple FIFO queue so we don't flood the API on page load
 const queue = [];
 let processing = false;
 
@@ -19,7 +15,6 @@ function truncate(text) {
   if (text.length <= MAX_CHARS) return { text, truncated: false };
 
   const candidate = text.substring(0, MAX_CHARS);
-  // Try to break at a Japanese sentence boundary
   const last = Math.max(
     candidate.lastIndexOf('\u3002'), // 。
     candidate.lastIndexOf('\uff01'), // ！
@@ -34,9 +29,15 @@ function truncate(text) {
   return { text: candidate, truncated: true };
 }
 
-async function fetchTranslation(text, langpair) {
-  const url = `${ENDPOINT}?q=${encodeURIComponent(text)}&langpair=${langpair}`;
-  const res = await fetch(url);
+// #5 — append registered email to raise quota from 5K → 50K chars/day
+function buildUrl(text, langpair, email) {
+  let url = `${ENDPOINT}?q=${encodeURIComponent(text)}&langpair=${langpair}`;
+  if (email) url += `&de=${encodeURIComponent(email)}`;
+  return url;
+}
+
+async function fetchTranslation(text, langpair, email) {
+  const res = await fetch(buildUrl(text, langpair, email));
   if (!res.ok) throw new Error(`MyMemory HTTP ${res.status}`);
   const data = await res.json();
   const translated = data?.responseData?.translatedText;
@@ -46,16 +47,16 @@ async function fetchTranslation(text, langpair) {
   return translated;
 }
 
-async function translateNow(text) {
+async function translateNow(text, lang1, lang2, email) {
   const { text: q, truncated } = truncate(text);
 
-  // Fire both language requests in parallel — they share the same rate-limit slot
-  const [en, fr] = await Promise.all([
-    fetchTranslation(q, 'ja|en').catch(() => '[translation unavailable]'),
-    fetchTranslation(q, 'ja|fr').catch(() => '[traduction indisponible]'),
+  // #4 — use configured language codes instead of hardcoded en/fr
+  const results = await Promise.all([
+    lang1 ? fetchTranslation(q, `ja|${lang1}`, email).catch(() => '[translation unavailable]') : Promise.resolve(null),
+    lang2 ? fetchTranslation(q, `ja|${lang2}`, email).catch(() => '[translation unavailable]') : Promise.resolve(null),
   ]);
 
-  return { en, fr, truncated };
+  return { lang1: results[0], lang2: results[1], truncated };
 }
 
 async function drainQueue() {
@@ -63,23 +64,22 @@ async function drainQueue() {
   processing = true;
 
   while (queue.length > 0) {
-    const { text, resolve, reject } = queue.shift();
+    const { text, lang1, lang2, email, resolve, reject } = queue.shift();
+    const cacheKey = `${text}|${lang1}|${lang2}`;
 
-    // Re-check cache in case a duplicate queued while we were waiting
-    if (cache.has(text)) {
-      resolve(cache.get(text));
+    if (cache.has(cacheKey)) {
+      resolve(cache.get(cacheKey));
       continue;
     }
 
     try {
-      const result = await translateNow(text);
-      cache.set(text, result);
+      const result = await translateNow(text, lang1, lang2, email);
+      cache.set(cacheKey, result);
       resolve(result);
     } catch (err) {
       reject(err);
     }
 
-    // ~1 tweet/second to stay well under MyMemory rate limits
     if (queue.length > 0) await sleep(1000);
   }
 
@@ -87,14 +87,22 @@ async function drainQueue() {
 }
 
 /**
- * Translate Japanese text to English and French.
- * Returns { en, fr, truncated }.
+ * Translate Japanese text using the configured language pair.
+ * Returns { lang1, lang2, truncated }.
+ *
+ * settings.lang1 / lang2  — #4 configurable language codes
+ * settings.myMemoryEmail  — #5 registered email for higher quota
  */
-export function translate(text) {
-  if (cache.has(text)) return Promise.resolve(cache.get(text));
+export function translate(text, settings = {}) {
+  const lang1 = settings.lang1 || 'en';
+  const lang2 = settings.lang2 || 'fr';
+  const email = settings.myMemoryEmail || '';
+  const cacheKey = `${text}|${lang1}|${lang2}`;
+
+  if (cache.has(cacheKey)) return Promise.resolve(cache.get(cacheKey));
 
   return new Promise((resolve, reject) => {
-    queue.push({ text, resolve, reject });
+    queue.push({ text, lang1, lang2, email, resolve, reject });
     drainQueue();
   });
 }


### PR DESCRIPTION
Closes #4, #5, #6

## Changes
| Issue | What changed |
|---|---|
| #4 Language slots | `translate()` uses `settings.lang1/lang2` — any MyMemory language code; cache key includes the pair; renderer shows proper language name from `LANG_NAMES` map |
| #5 MyMemory email | `&de=email` appended to every request when set — raises limit from 5K → 50K chars/day |
| #6 Click-to-translate | When enabled: token grid shown immediately + a pill button; clicking fires the API call; saves quota on heavy feeds |