### PR TITLE
feat: reading position above/below kanji + live options preview

### DIFF
--- a/src/content/renderer.js
+++ b/src/content/renderer.js
@@ -1,167 +1,4 @@
-const STYLES = `
-  :host { display: block !important; }
-
-  /* ── Font size — driven by --panel-font-size custom property (#10) ── */
-  :host { --panel-font-size: 14px; }
-  :host([data-size="small"])  { --panel-font-size: 11px; }
-  :host([data-size="large"])  { --panel-font-size: 17px; }
-
-  /* ── Light mode (default) ── */
-  .panel {
-    margin: 8px 0 4px;
-    padding: 10px 14px;
-    border-left: 3px solid rgba(29, 155, 240, 0.55);
-    background: rgba(29, 155, 240, 0.05);
-    border-radius: 0 6px 6px 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    font-size: var(--panel-font-size);
-    box-sizing: border-box;
-  }
-
-  /* ── Dark mode — applied when host has data-dark attribute ── */
-  :host([data-dark]) .panel {
-    background: rgba(29, 155, 240, 0.08);
-    border-left-color: rgba(29, 155, 240, 0.65);
-  }
-  :host([data-dark]) .token-surface { color: #e7e9ea; }
-  :host([data-dark]) .token-reading { color: rgb(29, 155, 240); }
-  :host([data-dark]) .token-romaji  { color: #71767b; }
-  :host([data-dark]) .token-plain   { color: #8b98a5; }
-  :host([data-dark]) .sep           { background: rgba(29, 155, 240, 0.2); }
-  :host([data-dark]) .value         { color: #e7e9ea; }
-  :host([data-dark]) .label         { color: rgb(29, 155, 240); }
-  :host([data-dark]) .loading       { color: #71767b; }
-  :host([data-dark]) .error         { color: #f4212e; }
-  :host([data-dark]) .note          { color: #71767b; }
-
-  /* ── Word-by-word token grid ── */
-
-  .token-grid {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 2px 1px;
-    padding-bottom: 8px;
-  }
-
-  /* A word cell stacks: kanji / hiragana reading / romaji */
-  .token-cell {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1px 4px;
-    min-width: 18px;
-  }
-
-  .token-surface {
-    font-size: 15px;
-    color: #0f1419;
-    line-height: 1.4;
-    text-align: center;
-  }
-
-  /* Hiragana reading — only shown when surface has kanji */
-  .token-reading {
-    font-size: 9.5px;
-    color: rgba(29, 155, 240, 0.9);
-    line-height: 1.3;
-    text-align: center;
-    font-weight: 500;
-  }
-
-  /* Romaji — shown for all Japanese tokens */
-  .token-romaji {
-    font-size: 9px;
-    color: #8899a6;
-    font-style: italic;
-    line-height: 1.3;
-    text-align: center;
-  }
-
-  /* Punctuation / Latin / numbers — inline, baseline-aligned */
-  .token-plain {
-    font-size: 15px;
-    color: #536471;
-    align-self: flex-end;
-    padding-bottom: 3px;
-    white-space: pre-wrap;
-  }
-
-  /* Forces a new line in the flex layout */
-  .token-break {
-    flex-basis: 100%;
-    height: 6px;
-  }
-
-  /* ── Translation rows ── */
-
-  .sep {
-    height: 1px;
-    background: rgba(29, 155, 240, 0.15);
-    margin: 2px 0 6px;
-  }
-
-  .row {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    padding: 2px 0;
-    font-size: 13px;
-    line-height: 1.55;
-    color: #536471;
-  }
-
-  .label {
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.6px;
-    color: rgba(29, 155, 240, 0.85);
-    min-width: 54px;
-    padding-top: 3px;
-    flex-shrink: 0;
-  }
-
-  .value {
-    flex: 1;
-    word-break: break-word;
-  }
-
-  /* ── Click-to-translate button (#6) ── */
-  .translate-btn {
-    margin-top: 4px;
-    padding: 4px 14px;
-    border: 1px solid rgba(29, 155, 240, 0.5);
-    border-radius: 9999px;
-    background: transparent;
-    color: rgb(29, 155, 240);
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.15s;
-  }
-  .translate-btn:hover { background: rgba(29, 155, 240, 0.1); }
-
-  /* ── States ── */
-
-  .loading {
-    color: #9aa5b1;
-    font-style: italic;
-    font-size: 12px;
-  }
-
-  .error {
-    font-size: 12px;
-    color: #e0245e;
-  }
-
-  .note {
-    font-size: 11px;
-    color: #9aa5b1;
-    font-style: italic;
-    margin-top: 4px;
-  }
-`;
+import { STYLES, buildTokenGrid, buildPanel } from '../lib/panel.js';
 
 /**
  * Detect X's dark mode by sampling the page background colour.
@@ -229,110 +66,22 @@ export function createAnnotationHost(tweetRoot, settings = {}) {
 /**
  * @param {HTMLElement} host
  * @param {Array}  tokens  — from getTokens()
- * @param {{ en, fr, truncated }} translations
+ * @param {{ lang1, lang2, truncated }} translations
+ * @param {object} settings
  */
-// Human-readable language names for the translation row labels
-const LANG_NAMES = {
-  en: 'English', fr: 'French',  es: 'Spanish',  de: 'German',
-  pt: 'Portuguese', it: 'Italian', nl: 'Dutch', pl: 'Polish',
-  ru: 'Russian', sv: 'Swedish', tr: 'Turkish', ar: 'Arabic',
-  zh: 'Chinese', ko: 'Korean',
-};
-
-export function updateAnnotation(host, tokens, { lang1, lang2, truncated }, settings = {}) {
-  const {
-    showReading = true,
-    showRomaji  = true,
-    showLang1   = true,
-    showLang2   = true,
-  } = settings;
+export function updateAnnotation(host, tokens, translations, settings = {}) {
   if (!host?.shadowRoot) return;
 
-  const panel = host.shadowRoot.querySelector('.panel');
-  panel.textContent = '';
+  const shadow = host.shadowRoot;
+  const style = shadow.querySelector('style');
 
-  // Token grid — word-by-word display
-  const grid = document.createElement('div');
-  grid.className = 'token-grid';
+  // Replace panel with freshly built one
+  const oldPanel = shadow.querySelector('.panel');
+  const newPanel = buildPanel(tokens, translations, settings);
+  shadow.replaceChild(newPanel, oldPanel);
 
-  for (const token of tokens) {
-    if (token.type === 'break') {
-      const br = document.createElement('div');
-      br.className = 'token-break';
-      grid.appendChild(br);
-      continue;
-    }
-
-    if (token.type === 'plain') {
-      const span = document.createElement('span');
-      span.className = 'token-plain';
-      span.textContent = token.surface;
-      grid.appendChild(span);
-      continue;
-    }
-
-    // type === 'word': kanji / hiragana reading / romaji
-    const cell = document.createElement('div');
-    cell.className = 'token-cell';
-
-    const surface = document.createElement('div');
-    surface.className = 'token-surface';
-    surface.textContent = token.surface;
-    cell.appendChild(surface);
-
-    if (token.reading && showReading) {
-      const reading = document.createElement('div');
-      reading.className = 'token-reading';
-      reading.textContent = token.reading;
-      cell.appendChild(reading);
-    }
-
-    if (token.romaji && showRomaji) {
-      const romaji = document.createElement('div');
-      romaji.className = 'token-romaji';
-      romaji.textContent = token.romaji;
-      cell.appendChild(romaji);
-    }
-
-    grid.appendChild(cell);
-  }
-
-  panel.appendChild(grid);
-
-  // Separator
-  const sep = document.createElement('div');
-  sep.className = 'sep';
-  panel.appendChild(sep);
-
-  // Translations — only render rows that are enabled (#3/#4)
-  const translationRows = [
-    { label: LANG_NAMES[settings.lang1] || settings.lang1 || 'English', value: lang1, show: showLang1 },
-    { label: LANG_NAMES[settings.lang2] || settings.lang2 || 'French',  value: lang2, show: showLang2 },
-  ].filter((r) => r.show && r.value && r.value !== '[translation unavailable]');
-
-  for (const { label, value } of translationRows) {
-    const row = document.createElement('div');
-    row.className = 'row';
-
-    const lbl = document.createElement('span');
-    lbl.className = 'label';
-    lbl.textContent = label;
-
-    const val = document.createElement('span');
-    val.className = 'value';
-    val.textContent = value;
-
-    row.appendChild(lbl);
-    row.appendChild(val);
-    panel.appendChild(row);
-  }
-
-  if (truncated) {
-    const note = document.createElement('div');
-    note.className = 'note';
-    note.textContent = 'Text was too long — translation may be partial.';
-    panel.appendChild(note);
-  }
+  // Re-attach style if it was removed
+  if (!shadow.querySelector('style')) shadow.prepend(style);
 }
 
 /**
@@ -341,49 +90,12 @@ export function updateAnnotation(host, tokens, { lang1, lang2, truncated }, sett
  */
 export function showTranslateButton(host, tokens, settings, onTranslate) {
   if (!host?.shadowRoot) return;
-  const panel = host.shadowRoot.querySelector('.panel');
-  panel.textContent = '';
+  const shadow = host.shadowRoot;
 
-  const { showReading = true, showRomaji = true } = settings;
-  const grid = document.createElement('div');
-  grid.className = 'token-grid';
-
-  for (const token of tokens) {
-    if (token.type === 'break') {
-      const br = document.createElement('div');
-      br.className = 'token-break';
-      grid.appendChild(br);
-      continue;
-    }
-    if (token.type === 'plain') {
-      const span = document.createElement('span');
-      span.className = 'token-plain';
-      span.textContent = token.surface;
-      grid.appendChild(span);
-      continue;
-    }
-    const cell = document.createElement('div');
-    cell.className = 'token-cell';
-    const surface = document.createElement('div');
-    surface.className = 'token-surface';
-    surface.textContent = token.surface;
-    cell.appendChild(surface);
-    if (token.reading && showReading) {
-      const reading = document.createElement('div');
-      reading.className = 'token-reading';
-      reading.textContent = token.reading;
-      cell.appendChild(reading);
-    }
-    if (token.romaji && showRomaji) {
-      const romaji = document.createElement('div');
-      romaji.className = 'token-romaji';
-      romaji.textContent = token.romaji;
-      cell.appendChild(romaji);
-    }
-    grid.appendChild(cell);
-  }
-
-  panel.appendChild(grid);
+  const oldPanel = shadow.querySelector('.panel');
+  const panel = document.createElement('div');
+  panel.className = 'panel';
+  panel.appendChild(buildTokenGrid(tokens, settings));
 
   const btn = document.createElement('button');
   btn.className = 'translate-btn';
@@ -397,6 +109,8 @@ export function showTranslateButton(host, tokens, settings, onTranslate) {
     onTranslate();
   }, { once: true });
   panel.appendChild(btn);
+
+  shadow.replaceChild(panel, oldPanel);
 }
 
 export function showAnnotationError(host, message = 'Translation failed.') {

--- a/src/lib/panel.js
+++ b/src/lib/panel.js
@@ -1,0 +1,292 @@
+/**
+ * Shared panel rendering — used by the content script renderer and
+ * the options-page live preview.
+ */
+
+export const STYLES = `
+  :host { display: block !important; }
+
+  /* ── Font size — driven by --panel-font-size custom property (#10) ── */
+  :host { --panel-font-size: 14px; }
+  :host([data-size="small"])  { --panel-font-size: 11px; }
+  :host([data-size="large"])  { --panel-font-size: 17px; }
+
+  /* ── Light mode (default) ── */
+  .panel {
+    margin: 8px 0 4px;
+    padding: 10px 14px;
+    border-left: 3px solid rgba(29, 155, 240, 0.55);
+    background: rgba(29, 155, 240, 0.05);
+    border-radius: 0 6px 6px 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: var(--panel-font-size);
+    box-sizing: border-box;
+  }
+
+  /* ── Dark mode — applied when host has data-dark attribute ── */
+  :host([data-dark]) .panel {
+    background: rgba(29, 155, 240, 0.08);
+    border-left-color: rgba(29, 155, 240, 0.65);
+  }
+  :host([data-dark]) .token-surface { color: #e7e9ea; }
+  :host([data-dark]) .token-reading { color: rgb(29, 155, 240); }
+  :host([data-dark]) .token-romaji  { color: #71767b; }
+  :host([data-dark]) .token-plain   { color: #8b98a5; }
+  :host([data-dark]) .sep           { background: rgba(29, 155, 240, 0.2); }
+  :host([data-dark]) .value         { color: #e7e9ea; }
+  :host([data-dark]) .label         { color: rgb(29, 155, 240); }
+  :host([data-dark]) .loading       { color: #71767b; }
+  :host([data-dark]) .error         { color: #f4212e; }
+  :host([data-dark]) .note          { color: #71767b; }
+
+  /* ── Word-by-word token grid ── */
+
+  .token-grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 2px 1px;
+    padding-bottom: 8px;
+  }
+
+  /* A word cell stacks: reading / kanji / romaji (above) or kanji / reading / romaji (below) */
+  .token-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1px 4px;
+    min-width: 18px;
+  }
+
+  .token-surface {
+    font-size: 15px;
+    color: #0f1419;
+    line-height: 1.4;
+    text-align: center;
+  }
+
+  /* Hiragana reading — only shown when surface has kanji */
+  .token-reading {
+    font-size: 9.5px;
+    color: rgba(29, 155, 240, 0.9);
+    line-height: 1.3;
+    text-align: center;
+    font-weight: 500;
+  }
+
+  /* Romaji — shown for all Japanese tokens */
+  .token-romaji {
+    font-size: 9px;
+    color: #8899a6;
+    font-style: italic;
+    line-height: 1.3;
+    text-align: center;
+  }
+
+  /* Punctuation / Latin / numbers — inline, baseline-aligned */
+  .token-plain {
+    font-size: 15px;
+    color: #536471;
+    align-self: flex-end;
+    padding-bottom: 3px;
+    white-space: pre-wrap;
+  }
+
+  /* Forces a new line in the flex layout */
+  .token-break {
+    flex-basis: 100%;
+    height: 6px;
+  }
+
+  /* ── Translation rows ── */
+
+  .sep {
+    height: 1px;
+    background: rgba(29, 155, 240, 0.15);
+    margin: 2px 0 6px;
+  }
+
+  .row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 2px 0;
+    font-size: 13px;
+    line-height: 1.55;
+    color: #536471;
+  }
+
+  .label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: rgba(29, 155, 240, 0.85);
+    min-width: 54px;
+    padding-top: 3px;
+    flex-shrink: 0;
+  }
+
+  .value {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  /* ── Click-to-translate button (#6) ── */
+  .translate-btn {
+    margin-top: 4px;
+    padding: 4px 14px;
+    border: 1px solid rgba(29, 155, 240, 0.5);
+    border-radius: 9999px;
+    background: transparent;
+    color: rgb(29, 155, 240);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .translate-btn:hover { background: rgba(29, 155, 240, 0.1); }
+
+  /* ── States ── */
+
+  .loading {
+    color: #9aa5b1;
+    font-style: italic;
+    font-size: 12px;
+  }
+
+  .error {
+    font-size: 12px;
+    color: #e0245e;
+  }
+
+  .note {
+    font-size: 11px;
+    color: #9aa5b1;
+    font-style: italic;
+    margin-top: 4px;
+  }
+`;
+
+// Human-readable language names for translation row labels
+export const LANG_NAMES = {
+  en: 'English', fr: 'French',  es: 'Spanish',  de: 'German',
+  pt: 'Portuguese', it: 'Italian', nl: 'Dutch', pl: 'Polish',
+  ru: 'Russian', sv: 'Swedish', tr: 'Turkish', ar: 'Arabic',
+  zh: 'Chinese', ko: 'Korean',
+};
+
+/**
+ * Build a token grid element from an array of tokens.
+ * Respects showReading, showRomaji, readingPosition (#15).
+ */
+export function buildTokenGrid(tokens, settings = {}) {
+  const {
+    showReading     = true,
+    showRomaji      = true,
+    readingPosition = 'below',
+  } = settings;
+
+  const grid = document.createElement('div');
+  grid.className = 'token-grid';
+
+  for (const token of tokens) {
+    if (token.type === 'break') {
+      const br = document.createElement('div');
+      br.className = 'token-break';
+      grid.appendChild(br);
+      continue;
+    }
+
+    if (token.type === 'plain') {
+      const span = document.createElement('span');
+      span.className = 'token-plain';
+      span.textContent = token.surface;
+      grid.appendChild(span);
+      continue;
+    }
+
+    // type === 'word'
+    const cell = document.createElement('div');
+    cell.className = 'token-cell';
+
+    const surface = document.createElement('div');
+    surface.className = 'token-surface';
+    surface.textContent = token.surface;
+
+    const readingEl = (token.reading && showReading)
+      ? Object.assign(document.createElement('div'), {
+          className: 'token-reading',
+          textContent: token.reading,
+        })
+      : null;
+
+    const romajiEl = (token.romaji && showRomaji)
+      ? Object.assign(document.createElement('div'), {
+          className: 'token-romaji',
+          textContent: token.romaji,
+        })
+      : null;
+
+    // #15 — reading position: above inserts reading before surface
+    if (readingPosition === 'above') {
+      if (readingEl) cell.appendChild(readingEl);
+      cell.appendChild(surface);
+    } else {
+      cell.appendChild(surface);
+      if (readingEl) cell.appendChild(readingEl);
+    }
+    if (romajiEl) cell.appendChild(romajiEl);
+
+    grid.appendChild(cell);
+  }
+
+  return grid;
+}
+
+/**
+ * Build a complete annotation panel: token grid + separator + translation rows.
+ */
+export function buildPanel(tokens, { lang1, lang2, truncated } = {}, settings = {}) {
+  const { showLang1 = true, showLang2 = true } = settings;
+
+  const panel = document.createElement('div');
+  panel.className = 'panel';
+
+  panel.appendChild(buildTokenGrid(tokens, settings));
+
+  const sep = document.createElement('div');
+  sep.className = 'sep';
+  panel.appendChild(sep);
+
+  const translationRows = [
+    { label: LANG_NAMES[settings.lang1] || settings.lang1 || 'English', value: lang1, show: showLang1 },
+    { label: LANG_NAMES[settings.lang2] || settings.lang2 || 'French',  value: lang2, show: showLang2 },
+  ].filter((r) => r.show && r.value && r.value !== '[translation unavailable]');
+
+  for (const { label, value } of translationRows) {
+    const row = document.createElement('div');
+    row.className = 'row';
+
+    const lbl = document.createElement('span');
+    lbl.className = 'label';
+    lbl.textContent = label;
+
+    const val = document.createElement('span');
+    val.className = 'value';
+    val.textContent = value;
+
+    row.appendChild(lbl);
+    row.appendChild(val);
+    panel.appendChild(row);
+  }
+
+  if (truncated) {
+    const note = document.createElement('div');
+    note.className = 'note';
+    note.textContent = 'Text was too long — translation may be partial.';
+    panel.appendChild(note);
+  }
+
+  return panel;
+}

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -18,6 +18,7 @@ export const DEFAULTS = {
   clickToTranslate: false,
   myMemoryEmail: '',
   minJapaneseChars: 2,
+  readingPosition: 'below', // 'above' | 'below'
 };
 
 /** Returns current settings merged with defaults. */

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -122,6 +122,41 @@ select { min-width: 160px; }
 input[type="number"] { width: 64px; text-align: center; }
 input[type="email"] { min-width: 200px; }
 
+/* ── Radio group ── */
+.radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+
+.radio-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #0f1419;
+  cursor: pointer;
+  user-select: none;
+}
+
+.radio-label input[type="radio"] {
+  accent-color: rgb(29, 155, 240);
+  cursor: pointer;
+}
+
+/* ── Live preview ── */
+.preview-hint {
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #71767b;
+}
+
+#preview-host {
+  border-radius: 6px;
+  overflow: hidden;
+}
+
 /* ── Save bar ── */
 .save-bar {
   position: fixed;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -51,6 +51,20 @@
       </label>
 
       <div class="field-row">
+        <label class="label-text">Reading position</label>
+        <div class="radio-group">
+          <label class="radio-label">
+            <input type="radio" name="readingPosition" value="above" />
+            Above kanji
+          </label>
+          <label class="radio-label">
+            <input type="radio" name="readingPosition" value="below" />
+            Below kanji
+          </label>
+        </div>
+      </div>
+
+      <div class="field-row">
         <label for="fontSize" class="label-text">Font size</label>
         <select id="fontSize">
           <option value="small">Small</option>
@@ -109,6 +123,12 @@
         </label>
         <input type="email" id="myMemoryEmail" placeholder="you@example.com" />
       </div>
+    </section>
+
+    <section>
+      <h2>Preview</h2>
+      <p class="hint preview-hint">日本語の勉強をしています</p>
+      <div id="preview-host"></div>
     </section>
 
     <div class="save-bar">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,4 +1,5 @@
 import { DEFAULTS, getSettings, saveSettings } from '../lib/settings.js';
+import { STYLES, buildPanel } from '../lib/panel.js';
 
 const LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -17,6 +18,23 @@ const LANGUAGES = [
   { code: 'ko', label: 'Korean' },
 ];
 
+// Pre-computed tokens for 日本語の勉強をしています (#16)
+const PREVIEW_TOKENS = [
+  { type: 'word', surface: '日本語', reading: 'にほんご', romaji: 'nihongo' },
+  { type: 'word', surface: 'の',     reading: null,       romaji: 'no' },
+  { type: 'word', surface: '勉強',   reading: 'べんきょう', romaji: 'benkyō' },
+  { type: 'word', surface: 'を',     reading: null,       romaji: 'wo' },
+  { type: 'word', surface: 'し',     reading: null,       romaji: 'shi' },
+  { type: 'word', surface: 'て',     reading: null,       romaji: 'te' },
+  { type: 'word', surface: 'い',     reading: null,       romaji: 'i' },
+  { type: 'word', surface: 'ます',   reading: null,       romaji: 'masu' },
+];
+const PREVIEW_TRANSLATIONS = {
+  lang1: 'I am studying Japanese.',
+  lang2: "J'étudie le japonais.",
+  truncated: false,
+};
+
 function populateSelect(id, selected) {
   const sel = document.getElementById(id);
   for (const { code, label } of LANGUAGES) {
@@ -29,6 +47,10 @@ function populateSelect(id, selected) {
 }
 
 function val(id) {
+  // Radio group: look for a checked radio with name=id
+  const radio = document.querySelector(`input[type="radio"][name="${id}"]:checked`);
+  if (radio) return radio.value;
+
   const el = document.getElementById(id);
   if (!el) return undefined;
   if (el.type === 'checkbox') return el.checked;
@@ -37,11 +59,51 @@ function val(id) {
 }
 
 function set(id, value) {
+  // Radio group
+  const radio = document.querySelector(`input[type="radio"][name="${id}"][value="${value}"]`);
+  if (radio) { radio.checked = true; return; }
+
   const el = document.getElementById(id);
   if (!el) return;
   if (el.type === 'checkbox') el.checked = Boolean(value);
   else el.value = value;
 }
+
+// ── Live preview (#16) ──────────────────────────────────────────────────────
+
+let previewShadow = null;
+
+function setupPreview() {
+  const container = document.getElementById('preview-host');
+  if (!container) return;
+  const host = document.createElement('div');
+  host.style.cssText = 'display:block;width:100%;';
+  container.appendChild(host);
+  previewShadow = host.attachShadow({ mode: 'open' });
+  const style = document.createElement('style');
+  style.textContent = STYLES;
+  previewShadow.appendChild(style);
+}
+
+function renderPreview() {
+  if (!previewShadow) return;
+
+  const settings = {};
+  for (const key of Object.keys(DEFAULTS)) {
+    settings[key] = val(key);
+  }
+
+  const oldPanel = previewShadow.querySelector('.panel');
+  const newPanel = buildPanel(PREVIEW_TOKENS, PREVIEW_TRANSLATIONS, settings);
+
+  if (oldPanel) {
+    previewShadow.replaceChild(newPanel, oldPanel);
+  } else {
+    previewShadow.appendChild(newPanel);
+  }
+}
+
+// ── Init ────────────────────────────────────────────────────────────────────
 
 async function init() {
   const settings = await getSettings();
@@ -53,6 +115,12 @@ async function init() {
     if (key === 'lang1' || key === 'lang2') continue; // already set via populateSelect
     set(key, settings[key]);
   }
+
+  setupPreview();
+  renderPreview();
+
+  // Re-render preview on any settings change
+  document.querySelector('.page').addEventListener('input', renderPreview);
 }
 
 document.getElementById('save').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary

- **#15 Reading position** — new `readingPosition: 'above' | 'below'` setting; radio buttons in the *Annotation display* section of the options page. When set to *above*, the hiragana reading floats above the kanji surface (traditional furigana style); *below* is the existing default.
- **#16 Live preview** — a preview card at the bottom of the options page renders `日本語の勉強をしています` using pre-computed tokens inside a Shadow DOM (identical styles to the real annotation). Every settings input change re-renders it instantly — no need to reload X.

### Implementation notes

- Extracted `STYLES`, `buildTokenGrid`, and `buildPanel` from `renderer.js` into a new shared module `src/lib/panel.js` so both the content script and the options page use the same rendering path.
- `buildTokenGrid` accepts `readingPosition` and inserts the reading element before or after the surface div accordingly.
- The live preview hooks a single `input` listener on `.page` — covers checkboxes, selects, radios, and text inputs in one shot.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Options page shows *Reading position* radio buttons with Above/Below options
- [ ] Preview card renders immediately on page open and updates on every settings change
- [ ] Setting *Above* flips hiragana reading above the kanji on real tweets
- [ ] Setting *Below* keeps existing layout
- [ ] Font size, showReading, showRomaji, dark mode all reflected in preview
- [ ] Save still persists all settings including `readingPosition`

Closes #15, #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)